### PR TITLE
Release/0.8.1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,14 +24,6 @@ jobs:
       - name: Setting up Git
         run: git config user.email "${{ github.actor }}@users.noreply.github.com" && git config user.name "Github Actions"
 
-      - name: Install gpg secret key
-        id: install-secret-key
-        run: |
-          # Install gpg secret key
-          cat <(echo -e "${{ secrets.OSSRH_SECRET_KEY }}") | gpg --batch --import
-          # Verify gpg secret key
-          gpg --list-secret-keys --keyid-format LONG
-
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -45,8 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
-          OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:
           gradle-version: wrapper
           arguments: clean spotlessCheck release -Prelease.useAutomaticVersion=true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Setting up Git
         run: git config user.email "${{ github.actor }}@users.noreply.github.com" && git config user.name "Github Actions"
 
+      - name: Install gpg secret key
+        id: install-secret-key
+        run: |
+          # Install gpg secret key
+          cat <(echo -e "${{ secrets.OSSRH_SECRET_KEY }}") | gpg --batch --import
+          # Verify gpg secret key
+          gpg --list-secret-keys --keyid-format LONG
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -37,7 +45,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
-          OSSRH_KEYID: ${{ secrets.OSSRH_KEYID }}
           OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
+          OSSRH_KEYID: ${{ secrets.OSSRH_KEYID }}
+          OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:
           gradle-version: wrapper
           arguments: clean spotlessCheck release -Prelease.useAutomaticVersion=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
+          OSSRH_KEYID: ${{ secrets.OSSRH_KEYID }}
+          OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:
           gradle-version: wrapper
-          arguments: clean spotlessCheck sonar publishAllPublicationsToSonatypeRepository
+          arguments: clean spotlessCheck sonar publish
 
   draft_release:
     name: Create Draft Tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install gpg secret key
+        id: install-secret-key
+        run: |
+          # Install gpg secret key
+          cat <(echo -e "${{ secrets.OSSRH_SECRET_KEY }}") | gpg --batch --import
+          # Verify gpg secret key
+          gpg --list-secret-keys --keyid-format LONG
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -34,7 +42,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
-          OSSRH_KEYID: ${{ secrets.OSSRH_KEYID }}
           OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install gpg secret key
-        id: install-secret-key
-        run: |
-          # Install gpg secret key
-          cat <(echo -e "${{ secrets.OSSRH_SECRET_KEY }}") | gpg --batch --import
-          # Verify gpg secret key
-          gpg --list-secret-keys --keyid-format LONG
-
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -42,8 +34,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
-          OSSRH_SECRET_KEY: ${{ secrets.OSSRH_SECRET_KEY }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:
           gradle-version: wrapper
           arguments: clean spotlessCheck sonar publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "io.github.pintowar"
-    description = "jweb-console"
+    description = "Web Scripting Console for Java Web Applications"
 }
 
 repositories {
@@ -77,6 +77,5 @@ tasks.sonar {
 }
 
 tasks.afterReleaseBuild {
-//    dependsOn(":sonar", ":publish")
-    dependsOn(":sonar")
+    dependsOn(":sonar", ":publish")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,5 +77,5 @@ tasks.sonar {
 }
 
 tasks.afterReleaseBuild {
-    dependsOn(":sonar", ":publish")
+    dependsOn(":sonar") // Maybe also :publish it? (need do gpg sign in gh action)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ configure<ReleaseExtension> {
 }
 
 tasks.sonar {
-    dependsOn(":testCodeCoverageReport")
+    dependsOn(":testCodeCoverageReport", ":jweb-console-webcli:testCodeCoverageReport")
 }
 
 tasks.afterReleaseBuild {

--- a/buildSrc/src/main/kotlin/extension.kt
+++ b/buildSrc/src/main/kotlin/extension.kt
@@ -2,6 +2,9 @@ import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.the
 
+val Project.isSnapshotVersion: Boolean
+    get() = version.toString().endsWith("SNAPSHOT")
+
 val Project.libs: LibrariesForLibs
     get() = the<LibrariesForLibs>()
 

--- a/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
@@ -53,9 +53,8 @@ publishing {
 }
 
 signing {
-    val signingKeyId = project.findProperty("signing.keyId")?.toString() ?: System.getenv("OSSRH_KEYID")
     val signingKey = project.findProperty("signing.secretKey")?.toString() ?: System.getenv("OSSRH_SECRET_KEY")
     val signingPassword = project.findProperty("signing.password")?.toString() ?: System.getenv("OSSRH_PASSWORD")
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications["maven"])
 }

--- a/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
@@ -53,5 +53,9 @@ publishing {
 }
 
 signing {
+    val signingKeyId = project.findProperty("signing.keyId")?.toString() ?: System.getenv("OSSRH_KEYID")
+    val signingKey = project.findProperty("signing.secretKey")?.toString() ?: System.getenv("OSSRH_SECRET_KEY")
+    val signingPassword = project.findProperty("signing.password")?.toString() ?: System.getenv("OSSRH_PASSWORD")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications["maven"])
 }

--- a/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("jweb-console.base")
     `maven-publish`
+    signing
 }
 
 publishing {
@@ -23,8 +24,10 @@ publishing {
             artifact(tasks["javadocJar"])
 
             pom {
-                name.set("JWeb Console")
-                description.set("Web Scripting Console for Java Web Applications")
+                name.set(project.name.trim().split("-").joinToString(" ") {
+                    it.replaceFirstChar(Char::uppercase)
+                })
+                description.set(project.description)
                 url.set("https://github.com/pintowar/jweb-console")
                 licenses {
                     license {
@@ -47,4 +50,8 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    sign(publishing.publications["maven"])
 }

--- a/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
@@ -10,7 +10,7 @@ publishing {
             name = "Sonatype"
             val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
             val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            setUrl(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            setUrl(if (isSnapshotVersion) snapshotsRepoUrl else releasesRepoUrl)
             credentials {
                 username = project.findProperty("ossrh.user")?.toString() ?: System.getenv("SONATYPE_USER")
                 password = project.findProperty("ossrh.pass")?.toString() ?: System.getenv("SONATYPE_PASS")
@@ -52,9 +52,11 @@ publishing {
     }
 }
 
-signing {
-    val signingKey = project.findProperty("signing.secretKey")?.toString() ?: System.getenv("OSSRH_SECRET_KEY")
-    val signingPassword = project.findProperty("signing.password")?.toString() ?: System.getenv("OSSRH_PASSWORD")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["maven"])
+if (!isSnapshotVersion) {
+    signing {
+        val signingKey = project.findProperty("signing.secretKey")?.toString() ?: System.getenv("OSSRH_SECRET_KEY")
+        val signingPassword = project.findProperty("signing.password")?.toString() ?: System.getenv("OSSRH_PASSWORD")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["maven"])
+    }
 }

--- a/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jweb-console.publish.gradle.kts
@@ -21,6 +21,30 @@ publishing {
             from(components["java"])
             artifact(tasks["sourcesJar"])
             artifact(tasks["javadocJar"])
+
+            pom {
+                name.set("JWeb Console")
+                description.set("Web Scripting Console for Java Web Applications")
+                url.set("https://github.com/pintowar/jweb-console")
+                licenses {
+                    license {
+                        name.set("The MIT License (MIT)")
+                        url.set("https://mit-license.org/license.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("pintowar")
+                        name.set("Thiago Oliveira")
+                        email.set("pintowar@gmail.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/pintowar/jweb-console.git")
+                    developerConnection.set("scm:git:ssh://github.com/pintowar/jweb-console.git")
+                    url.set("https://github.com/pintowar/jweb-console/")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
No extra features or bug fixes!

Just add new configuration for release creation and central maven publishing.

For Github Actions run when pushes are made on branches: 

* `develop`: sonar reports will be deployed to sonarcloud;
* `releases/*`: sonar reports will be deployed to sonarcloud AND publish unsigned jars to sonatype snapshot repository AND create a draft release on Github;
* `master`: sonar reports will be deployed to sonarcloud AND creates a Github tag + release with the released version.

To actually publish the released artifacts to MavenCentral, the author will have to checkout to the git released version and run the `gradle publish` command locally (or wherever it may contains a GPG key). This is a more secure way (where a GPG key info may not be shared on remote machines).
